### PR TITLE
🐛 Fix invalid import

### DIFF
--- a/src/output/YesNoOutput.ts
+++ b/src/output/YesNoOutput.ts
@@ -1,5 +1,4 @@
-import { BaseOutput, Output } from '@jovotech/framework';
-import { OutputTemplate } from '@jovotech/output';
+import { BaseOutput, Output, OutputTemplate } from '@jovotech/framework';
 
 @Output()
 export class YesNoOutput extends BaseOutput {


### PR DESCRIPTION
`@jovotech/output` is not a direct dependency, therefore the `OutputTemplate` should be imported from `@jovotech/framework` which re-exports some classes and interfaces of `@jovotech/output`.