### PR TITLE
:arrow_up: Upgrade esbuild dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
     "bestzip": "^2.1.7",
-    "esbuild": "^0.12.5",
+    "esbuild": "^0.14.2",
     "eslint": "^7.17.0",
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-prettier": "^3.3.1",


### PR DESCRIPTION
Fixes npm error on `jovo new` or `npm i` (node 16)

![image](https://user-images.githubusercontent.com/14978292/145552185-843e6df7-07b6-48be-98a1-d097d8c5c241.png)
