### PR TITLE
➕ Add @jovotech/cli dependency

### DIFF
--- a/jovo.project.js
+++ b/jovo.project.js
@@ -1,4 +1,4 @@
-const { ProjectConfig } = require('@jovotech/cli-core');
+const { ProjectConfig } = require('@jovotech/cli');
 
 /*
 |--------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {
-    "@jovotech/cli-core": "^4.0.0",
+    "@jovotech/cli": "^4.0.0",
     "@types/express": "^4.17.11",
     "@types/jest": "^27.0.2",
     "@types/socket.io-client": "^1.4.36",


### PR DESCRIPTION
This PR adds `@jovotech/cli` as a dependency, instead of `@jovotech/cli-core`, in correspondence with jovotech/jovo-cli/pull/276